### PR TITLE
mbim: support retrieving and reporting unlock retries information for multiple PIN types

### DIFF
--- a/src/mm-broadband-modem-mbim.c
+++ b/src/mm-broadband-modem-mbim.c
@@ -93,6 +93,9 @@ struct _MMBroadbandModemMbimPrivate {
 
     /* For notifying when the mbim-proxy connection is dead */
     gulong mbim_device_removed_id;
+
+    /* Previously observed SIM-PIN remaining retries */
+    guint sim_pin_retries;
 };
 
 /*****************************************************************************/
@@ -710,16 +713,47 @@ pin_query_unlock_retries_ready (MbimDevice *device,
             NULL,
             &remaining_attempts,
             &error)) {
+        MMBroadbandModemMbim *self;
+        MMModemLock lock;
         MMUnlockRetries *retries;
 
+        self = g_task_get_source_object (task);
+        lock = mm_modem_lock_from_mbim_pin_type (pin_type);
         retries = mm_unlock_retries_new ();
+
+        /* If PIN1 is disabled and we have tried to enable it with a wrong PIN,
+         * the modem would have indicated the number of remaining attempts for
+         * PIN1 (unless PUK1 is engaged) in the response to the failed
+         * MBIM_CID_PIN set operation. Thus, MMSimMbim would have updated
+         * MMIfaceModem's MMUnlockRetries with information about PIN1.
+         *
+         * However, a MBIM_CID_PIN query may be issued (e.g. MMBaseSim calls
+         * mm_iface_modem_update_lock_info()) after the MBIM_CID_PIN set
+         * operation to query the number of remaining attempts for a PIN type.
+         * Unfortunately, we can't specify a particular PIN type in a
+         * MBIM_CID_PIN query. The modem may not reply with information about
+         * PIN1 if PIN1 is disabled. When that happens, we would like to
+         * preserve our knowledge about the number of remaining attempts for
+         * PIN1. Here we thus carry over any existing information on PIN1 from
+         * MMIfaceModem's MMUnlockRetries if the MBIM_CID_PIN query reports
+         * something other than PIN1. */
+        if (lock != MM_MODEM_LOCK_SIM_PIN &&
+            self->priv->sim_pin_retries != MM_UNLOCK_RETRIES_UNKNOWN) {
+            mm_unlock_retries_set (retries,
+                                   MM_MODEM_LOCK_SIM_PIN,
+                                   self->priv->sim_pin_retries);
+        }
+
         /* According to the MBIM specification, RemainingAttempts is set to
          * 0xffffffff if the device does not support this information. */
-        if (remaining_attempts != G_MAXUINT32) {
-            mm_unlock_retries_set (retries,
-                                   mm_modem_lock_from_mbim_pin_type (pin_type),
-                                   remaining_attempts);
-        }
+        if (remaining_attempts != G_MAXUINT32)
+            mm_unlock_retries_set (retries, lock, remaining_attempts);
+        else
+            remaining_attempts = MM_UNLOCK_RETRIES_UNKNOWN;
+
+        if (lock == MM_MODEM_LOCK_SIM_PIN)
+            self->priv->sim_pin_retries = remaining_attempts;
+
         g_task_return_pointer (task, retries, g_object_unref);
     } else
         g_task_return_error (task, error);
@@ -3240,6 +3274,8 @@ mm_broadband_modem_mbim_init (MMBroadbandModemMbim *self)
     self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self,
                                               MM_TYPE_BROADBAND_MODEM_MBIM,
                                               MMBroadbandModemMbimPrivate);
+
+    self->priv->sim_pin_retries = MM_UNLOCK_RETRIES_UNKNOWN;
 }
 
 static void

--- a/src/mm-iface-modem.c
+++ b/src/mm-iface-modem.c
@@ -2926,9 +2926,9 @@ set_lock_status (MMIfaceModem *self,
     }
 }
 
-static void
-update_unlock_retries (MMIfaceModem *self,
-                       MMUnlockRetries *unlock_retries)
+void
+mm_iface_modem_update_unlock_retries (MMIfaceModem *self,
+                                      MMUnlockRetries *unlock_retries)
 {
     MmGdbusModem *skeleton = NULL;
     GVariant *previous_dictionary;
@@ -3016,7 +3016,7 @@ load_unlock_retries_ready (MMIfaceModem *self,
         g_error_free (error);
     } else {
         /* Update the dictionary in the DBus interface */
-        update_unlock_retries (self, unlock_retries);
+        mm_iface_modem_update_unlock_retries (self, unlock_retries);
         g_object_unref (unlock_retries);
     }
 

--- a/src/mm-iface-modem.h
+++ b/src/mm-iface-modem.h
@@ -414,6 +414,9 @@ MMModemLock mm_iface_modem_update_lock_info_finish (MMIfaceModem *self,
                                                     GAsyncResult *res,
                                                     GError **error);
 
+void mm_iface_modem_update_unlock_retries (MMIfaceModem *self,
+                                           MMUnlockRetries *unlock_retries);
+
 /* Request signal quality check update.
  * It will not only return the signal quality status, but also set the property
  * values in the DBus interface. */


### PR DESCRIPTION
After MMSimMbim performs a MBIM_CID_PIN set operation, it calls mm_iface_modem_update_lock_info() (through its base class MMBaseSim) to refresh the unlock retries information, which results in a MBIM_CID_PIN query. However, a MBIM_CID_PIN query reports only the information of one PIN type and the PIN type can't be specified, we need to deduce the number of retries left for a specific PIN type from the response of a MBIM_CID_PIN set operation for that PIN type. This patch set adds support for retrieving and reporting unlock retries information for multiple PIN types on MBIM modems.